### PR TITLE
Refactor greeter to use MCP server wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project showcases how to integrate LangGraph with MCP tools to create an in
 - File reading and creation
 - Proper resource management with async context managers
 - Structured LangGraph workflow
+- Simple wrappers for each MCP server with namespaced tools
 
 ## Requirements
 
@@ -107,6 +108,7 @@ if __name__ == "__main__":
 ## Project Structure
 
 - `mcp_graph_greeter.py` - Main implementation of the graph and LangGraph CLI entry point
+- `mcp_servers.py` - Wrappers for launching MCP servers and loading namespaced tools
 - `greeter_service.py` - Service functions for using the greeter in applications
 - `config.py` - Configuration for the MCP server
 - `demo.py` - Command-line demo script

--- a/mcp_graph_greeter.py
+++ b/mcp_graph_greeter.py
@@ -16,9 +16,10 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.tools import BaseTool
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_openai import ChatOpenAI
 from langchain_core.runnables import RunnableConfig
+
+from mcp_servers import build_wrappers, load_all_tools
 
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
@@ -286,36 +287,19 @@ async def graph_factory():
         "shell_execute",
     ]
 
-    # Initialize tools list
-    all_tools = []
+    allowed = {"filesystem": allowed_tools, "shell": allowed_tools}
 
-    # Create a combined client for all servers
-    all_servers = {}
-    all_servers.update({"filesystem": MCP_SERVERS["filesystem"]})
-    all_servers.update({"context7": MCP_SERVERS["context7"]})
-    all_servers.update({"shell": MCP_SERVERS["shell"]})
-
-    # Create a single client for all servers
-    client = MultiServerMCPClient(all_servers)
+    wrappers = build_wrappers(MCP_SERVERS, allowed)
 
     try:
-        # Get all tools directly without sessions
-        # This approach uses the client's built-in methods to handle session management
-        tools = await client.get_tools()
+        tools = await load_all_tools(wrappers)
         logger.info(f"Loaded {len(tools)} total tools")
 
-        # Filter filesystem tools if needed
-        fs_tools_filtered = [t for t in tools if t.name in allowed_tools]
-        logger.info(f"Using {len(fs_tools_filtered)}/{len(tools)} allowed tools")
-        all_tools.extend(fs_tools_filtered)
-
-        # Create graph with all tools
-        graph = build_greeter_graph(all_tools, sensitive_tools)
+        graph = build_greeter_graph(tools, sensitive_tools)
         logger.info(
-            f"MCP Graph Greeter created with {len(all_tools)} tools ({len(sensitive_tools)} requiring approval)"
+            f"MCP Graph Greeter created with {len(tools)} tools ({len(sensitive_tools)} requiring approval)"
         )
 
-        # Yield graph while keeping sessions active
         yield graph
 
     except Exception as e:

--- a/mcp_servers.py
+++ b/mcp_servers.py
@@ -1,0 +1,42 @@
+"""Wrappers and helpers for launching MCP servers and loading tools."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+@dataclass
+class MCPServerWrapper:
+    """Simple wrapper around a single MCP server."""
+
+    name: str
+    config: Dict
+    allowed_tools: Optional[List[str]] = None
+
+    async def get_tools(self) -> List[BaseTool]:
+        """Return namespaced tools for this server."""
+        async with MultiServerMCPClient({self.name: self.config}) as client:
+            tools = await client.get_tools()
+        if self.allowed_tools:
+            tools = [t for t in tools if t.name in self.allowed_tools]
+        for tool in tools:
+            tool.name = f"{self.name}:{tool.name}"
+        return tools
+
+
+def build_wrappers(servers: Dict[str, Dict], allowed: Optional[Dict[str, List[str]]] = None) -> Dict[str, MCPServerWrapper]:
+    """Create wrappers for a mapping of servers."""
+    allowed = allowed or {}
+    return {
+        name: MCPServerWrapper(name, cfg, allowed.get(name)) for name, cfg in servers.items()
+    }
+
+
+async def load_all_tools(wrappers: Dict[str, MCPServerWrapper]) -> List[BaseTool]:
+    """Load tools from all wrappers."""
+    all_tools: List[BaseTool] = []
+    for wrapper in wrappers.values():
+        all_tools.extend(await wrapper.get_tools())
+    return all_tools


### PR DESCRIPTION
## Summary
- organize each MCP server behind a wrapper and namespace tool names
- integrate wrappers in `graph_factory`
- document new wrappers in README

## Testing
- `python -m py_compile mcp_graph_greeter.py mcp_servers.py greeter_service.py`
- `python -m pytest -q` *(fails: No module named pytest)*