### PR TITLE
Refine wrapper usage and tool review logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project showcases how to integrate LangGraph with MCP tools to create an in
 - File reading and creation
 - Proper resource management with async context managers
 - Structured LangGraph workflow
+- Simple wrappers for each MCP server, with tool names automatically
+  prefixed by the server name
 
 ## Requirements
 
@@ -107,6 +109,7 @@ if __name__ == "__main__":
 ## Project Structure
 
 - `mcp_graph_greeter.py` - Main implementation of the graph and LangGraph CLI entry point
+- `mcp_servers.py` - Wrappers for launching MCP servers and loading namespaced tools
 - `greeter_service.py` - Service functions for using the greeter in applications
 - `config.py` - Configuration for the MCP server
 - `demo.py` - Command-line demo script

--- a/mcp_servers.py
+++ b/mcp_servers.py
@@ -1,0 +1,42 @@
+"""Wrappers and helpers for launching MCP servers and loading tools."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+@dataclass
+class MCPServerWrapper:
+    """Simple wrapper around a single MCP server."""
+
+    name: str
+    config: Dict
+    allowed_tools: Optional[List[str]] = None
+
+    async def get_tools(self) -> List[BaseTool]:
+        """Return namespaced tools for this server."""
+        client = MultiServerMCPClient({self.name: self.config})
+        tools = await client.get_tools()
+        if self.allowed_tools:
+            tools = [t for t in tools if t.name in self.allowed_tools]
+        for tool in tools:
+            tool.name = f"{self.name}:{tool.name}"
+        return tools
+
+
+def build_wrappers(servers: Dict[str, Dict], allowed: Optional[Dict[str, List[str]]] = None) -> Dict[str, MCPServerWrapper]:
+    """Create wrappers for a mapping of servers."""
+    allowed = allowed or {}
+    return {
+        name: MCPServerWrapper(name, cfg, allowed.get(name)) for name, cfg in servers.items()
+    }
+
+
+async def load_all_tools(wrappers: Dict[str, MCPServerWrapper]) -> List[BaseTool]:
+    """Load tools from all wrappers."""
+    all_tools: List[BaseTool] = []
+    for wrapper in wrappers.values():
+        all_tools.extend(await wrapper.get_tools())
+    return all_tools


### PR DESCRIPTION
## Summary
- fix `MCPServerWrapper.get_tools` to avoid using `MultiServerMCPClient` as an async context manager
- make review logic server-name aware by stripping namespace before comparison
- clarify README about namespaced tools

## Testing
- `python -m py_compile mcp_graph_greeter.py mcp_servers.py greeter_service.py`
- `pytest -q` *(fails: command not found)*