### PR TITLE
Implement namespaced server config loading

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -59,3 +59,16 @@ FILESYSTEM_SERVER = {"filesystem": MCP_SERVERS["filesystem"]}
 
 logger.info(f"Configured workspace directory: {WORKSPACE_DIR}")
 logger.info(f"Using LLM model: {LLM_MODEL_NAME}")
+
+from .loader import load_server_configs, ServerConfig, ConfigLoaderError
+
+__all__ = [
+    "MCP_SERVERS",
+    "FILESYSTEM_SERVER",
+    "OPENAI_API_KEY",
+    "LLM_MODEL_NAME",
+    "WORKSPACE_DIR",
+    "load_server_configs",
+    "ServerConfig",
+    "ConfigLoaderError",
+]

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict
+
+from . import WORKSPACE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServerConfig:
+    server_name: str
+    endpoint: Dict
+    allowed_tools: List[str]
+    sensitive_tools: List[str]
+
+
+class ConfigLoaderError(Exception):
+    pass
+
+
+def load_server_configs(directory: Path | str = Path(__file__).parent / "servers") -> List[ServerConfig]:
+    """Load server configurations from JSON files in ``directory``.
+
+    Parameters
+    ----------
+    directory : Path or str
+        Directory containing ``*.json`` server configuration files.
+
+    Returns
+    -------
+    List[ServerConfig]
+        Parsed server configurations.
+    """
+    dir_path = Path(directory)
+    configs: List[ServerConfig] = []
+    if not dir_path.exists():
+        raise ConfigLoaderError(f"Config directory not found: {dir_path}")
+
+    for json_file in dir_path.glob("*.json"):
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as e:  # JSONDecodeError or others
+            raise ConfigLoaderError(f"Failed to parse {json_file}: {e}")
+
+        missing = [k for k in ["server_name", "endpoint", "allowed_tools", "sensitive_tools"] if k not in data]
+        if missing:
+            raise ConfigLoaderError(f"{json_file}: missing keys: {', '.join(missing)}")
+        if not isinstance(data["allowed_tools"], list) or not isinstance(data["sensitive_tools"], list):
+            raise ConfigLoaderError(f"{json_file}: 'allowed_tools' and 'sensitive_tools' must be lists")
+
+        endpoint = data["endpoint"]
+        # Replace workspace placeholder if present in args
+        args = endpoint.get("args", [])
+        endpoint["args"] = [str(a).replace("${WORKSPACE_DIR}", str(WORKSPACE_DIR)) for a in args]
+
+        configs.append(
+            ServerConfig(
+                server_name=data["server_name"],
+                endpoint=endpoint,
+                allowed_tools=data["allowed_tools"],
+                sensitive_tools=data["sensitive_tools"],
+            )
+        )
+
+    return configs

--- a/config/servers/context7.json
+++ b/config/servers/context7.json
@@ -1,0 +1,13 @@
+{
+  "server_name": "context7",
+  "endpoint": {
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp@latest"],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "resolve-library-id",
+    "get-library-docs"
+  ],
+  "sensitive_tools": []
+}

--- a/config/servers/filesystem.json
+++ b/config/servers/filesystem.json
@@ -1,0 +1,26 @@
+{
+  "server_name": "filesystem",
+  "endpoint": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "${WORKSPACE_DIR}"],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "read_file",
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "list_directory",
+    "directory_tree",
+    "move_file",
+    "search_files",
+    "get_file_info",
+    "list_allowed_directories"
+  ],
+  "sensitive_tools": [
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "move_file"
+  ]
+}

--- a/config/servers/shell.json
+++ b/config/servers/shell.json
@@ -1,0 +1,15 @@
+{
+  "server_name": "shell",
+  "endpoint": {
+    "command": "uvx",
+    "args": ["mcp-shell-server"],
+    "env": {"ALLOW_COMMANDS": "ls,cat,pwd,grep,wc,touch,find,date,whoami"},
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "shell_execute"
+  ],
+  "sensitive_tools": [
+    "shell_execute"
+  ]
+}

--- a/mcp_graph_greeter.py
+++ b/mcp_graph_greeter.py
@@ -26,7 +26,13 @@ from langgraph.constants import END, START
 from langgraph.prebuilt.tool_node import ToolNode
 
 # Import MCP server configuration
-from config import MCP_SERVERS, OPENAI_API_KEY, LLM_MODEL_NAME
+from config import (
+    MCP_SERVERS,  # backward compatibility
+    OPENAI_API_KEY,
+    LLM_MODEL_NAME,
+    load_server_configs,
+    ServerConfig,
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -50,6 +56,13 @@ class GreeterState(TypedDict, total=False):
     """State type for the MCP graph greeter."""
 
     messages: Annotated[List[BaseMessage], add_messages]
+
+
+def split_namespaced(name: str) -> tuple[str, str]:
+    """Split a namespaced tool name into (server, tool)."""
+    if "." not in name:
+        raise ValueError(f"Tool name '{name}' is not namespaced")
+    return name.split(".", 1)
 
 
 
@@ -153,9 +166,12 @@ def build_greeter_graph(
 
         tool_call = last_message.tool_calls[0]
         tool_name = tool_call["name"]
+        try:
+            server, base_tool = split_namespaced(tool_name)
+        except ValueError:
+            server, base_tool = None, tool_name
 
         # Only request human approval for specific sensitive tools defined at the graph_factory level
-
         # If the tool is not in our sensitive list, skip review
         if tool_name not in sensitive_tools:
             logger.info(f"Tool '{tool_name}' not sensitive - skipping review")
@@ -262,60 +278,44 @@ async def graph_factory():
     """
     logger.info("Initializing MCP Graph Greeter for LangGraph CLI")
 
-    # Define allowed tools and sensitive tools that require approval
-    allowed_tools = [
-        "resolve-library-id",
-        "get-library-docs",
-        "read_file",
-        "write_file",
-        "edit_file",
-        "create_directory",
-        "list_directory",
-        "directory_tree",
-        "move_file",
-        "search_files",
-        "get_file_info",
-        "list_allowed_directories",
-        "shell_execute",
-    ]
-    sensitive_tools = [
-        "write_file",
-        "edit_file",
-        "create_directory",
-        "move_file",
-        "shell_execute",
-    ]
+    configs = load_server_configs()
+    server_map = {c.server_name: c.endpoint for c in configs}
+    allowed_map = {c.server_name: set(c.allowed_tools) for c in configs}
+    sensitive_map = {c.server_name: set(c.sensitive_tools) for c in configs}
 
-    # Initialize tools list
-    all_tools = []
-
-    # Create a combined client for all servers
-    all_servers = {}
-    all_servers.update({"filesystem": MCP_SERVERS["filesystem"]})
-    all_servers.update({"context7": MCP_SERVERS["context7"]})
-    all_servers.update({"shell": MCP_SERVERS["shell"]})
-
-    # Create a single client for all servers
-    client = MultiServerMCPClient(all_servers)
+    client = MultiServerMCPClient(server_map)
 
     try:
-        # Get all tools directly without sessions
-        # This approach uses the client's built-in methods to handle session management
         tools = await client.get_tools()
         logger.info(f"Loaded {len(tools)} total tools")
 
-        # Filter filesystem tools if needed
-        fs_tools_filtered = [t for t in tools if t.name in allowed_tools]
-        logger.info(f"Using {len(fs_tools_filtered)}/{len(tools)} allowed tools")
-        all_tools.extend(fs_tools_filtered)
+        namespaced_tools: List[BaseTool] = []
+        seen = set()
 
-        # Create graph with all tools
-        graph = build_greeter_graph(all_tools, sensitive_tools)
+        for tool in tools:
+            server = tool.metadata.get("server") or tool.metadata.get("server_name")
+            if not server:
+                raise ValueError(f"Tool {tool.name} missing server metadata")
+
+            if tool.name not in allowed_map.get(server, set()):
+                continue
+
+            namespaced = f"{server}.{tool.name}"
+            if namespaced in seen:
+                raise ValueError(f"Duplicate tool after namespacing: {namespaced}")
+            seen.add(namespaced)
+
+            tool.metadata["original_name"] = tool.name
+            tool.name = namespaced
+            namespaced_tools.append(tool)
+
+        sensitive_names = [f"{srv}.{name}" for srv, names in sensitive_map.items() for name in names]
+
+        graph = build_greeter_graph(namespaced_tools, sensitive_names)
         logger.info(
-            f"MCP Graph Greeter created with {len(all_tools)} tools ({len(sensitive_tools)} requiring approval)"
+            f"MCP Graph Greeter created with {len(namespaced_tools)} tools ({len(sensitive_names)} requiring approval)"
         )
 
-        # Yield graph while keeping sessions active
         yield graph
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- move `config.py` into package and export loader
- load per-server JSON configuration dynamically
- namespace tools per server in `graph_factory`
- add helper `split_namespaced`
- add loader tests and namespacing tests

## Testing
- `python -m py_compile mcp_graph_greeter.py config/__init__.py config/loader.py tests/test_greeter.py greeter_service.py`
- ❌ `flake8` *(failed: command not found)*
- ❌ `pytest -q` *(failed: command not found)*