### PR TITLE
Per-Server Configuration & Namespaced Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project showcases how to integrate LangGraph with MCP tools to create an in
 - File reading and creation
 - Proper resource management with async context managers
 - Structured LangGraph workflow
+- Server configuration via JSON files
+- Tool namespacing for uniqueness across servers
 
 ## Requirements
 
@@ -26,22 +28,67 @@ This project showcases how to integrate LangGraph with MCP tools to create an in
 ## Installation
 
 1. Clone this repository
-2. Install the LangGraph CLI and dependencies using uvx:
+2. Install the package and its dependencies:
+
+```bash
+# Using uv (recommended)
+uv install -e .
+
+# Or using pip
+pip install -e .
+```
+
+3. Install the LangGraph CLI:
 
 ```bash
 pip install uvx
 ```
 
-3. Install the MCP filesystem server:
+4. Install the MCP filesystem server:
 
 ```bash
 npm install -g @modelcontextprotocol/server-filesystem
 ```
 
-4. Configure environment variables:
+5. Configure environment variables:
    - Copy `.env.example` to `.env`
    - Add your OpenAI API key to the `.env` file
    - Optionally change the model name from the default "gpt-4.1" to another OpenAI model
+
+## Server Configuration
+
+The MCP Graph Greeter uses a data-driven approach for configuring MCP servers. Each server has its own JSON configuration file in the `config/servers/` directory.
+
+### Configuration Format
+
+Each server configuration file should follow this structure:
+
+```json
+{
+  "server_name": "filesystem",
+  "endpoint": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "./"],
+    "transport": "stdio"
+  },
+  "allowed_tools": ["read_file", "write_file", "list_directory"],
+  "sensitive_tools": ["write_file"]
+}
+```
+
+### Adding a New Server
+
+To add a new MCP server:
+
+1. Create a new JSON file in the `config/servers/` directory
+2. Define the server_name, endpoint, allowed_tools, and sensitive_tools
+3. Restart the application
+
+No code changes are required to add a new server.
+
+### Tool Namespacing
+
+All tools are namespaced using the pattern `<server_name>_<tool_name>` to ensure uniqueness. For example, the `read_file` tool from the `filesystem` server becomes `filesystem_read_file`. This prevents conflicts when multiple servers provide tools with the same name and ensures compatibility with OpenAI's tool name requirements.
 
 ## Usage
 
@@ -55,7 +102,7 @@ uvx --refresh --from "langgraph-cli[inmem]" --with-editable . --python 3.11 lang
 
 This will:
 1. Start the LangGraph development server
-2. Launch the MCP filesystem server
+2. Launch the MCP servers defined in the configuration files
 3. Create the graph with all necessary tools
 4. Open a web interface for interacting with the assistant
 
@@ -108,7 +155,14 @@ if __name__ == "__main__":
 
 - `mcp_graph_greeter.py` - Main implementation of the graph and LangGraph CLI entry point
 - `greeter_service.py` - Service functions for using the greeter in applications
-- `config.py` - Configuration for the MCP server
+- `config/` - Configuration package
+  - `__init__.py` - Basic configuration and environment variables
+  - `loader.py` - Server configuration loader
+  - `schema.py` - JSON schema for server configurations
+  - `servers/` - Directory containing server configuration files
+    - `filesystem.json` - Filesystem server configuration
+    - `context7.json` - Context7 server configuration
+    - `shell.json` - Shell command server configuration
 - `demo.py` - Command-line demo script
 - `langgraph.json` - Configuration for the LangGraph CLI
 - `__init__.py` - Package definition
@@ -116,6 +170,8 @@ if __name__ == "__main__":
 ## Security Considerations
 
 This demo only allows access to the current working directory for safety reasons. The MCP filesystem server restricts file operations to this directory tree.
+
+The configuration system lets you mark specific tools as sensitive, requiring human approval before execution.
 
 ## Acknowledgements
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,27 @@
+"""
+Configuration package for MCP Graph Greeter
+"""
+
+import os
+import logging
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from .env file if it exists
+load_dotenv()
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Application paths
+BASE_DIR = Path(__file__).parent.parent
+WORKSPACE_DIR = os.getcwd()  # Use current working directory as workspace
+
+# API configuration
+# Check for OpenAI API key in environment variables (empty by default, will use system config)
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+LLM_MODEL_NAME = os.environ.get("LLM_MODEL_NAME", "gpt-4.1")
+
+logger.info(f"Configured workspace directory: {WORKSPACE_DIR}")
+logger.info(f"Using LLM model: {LLM_MODEL_NAME}")

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,200 @@
+"""
+Configuration loader for MCP Graph Greeter
+
+Loads server configurations from JSON files in the config/servers directory.
+"""
+
+import os
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Any
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+# Try to import jsonschema, but provide fallback if not available
+try:
+    import jsonschema
+    HAVE_JSONSCHEMA = True
+except ImportError:
+    logger.warning("jsonschema package not found. Using basic validation instead.")
+    HAVE_JSONSCHEMA = False
+
+from config.schema import SERVER_CONFIG_SCHEMA
+
+def basic_validate_config(config: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    """
+    Basic validation for server configurations when jsonschema is not available.
+    
+    Args:
+        config: Configuration to validate
+        schema: Schema to validate against
+    
+    Raises:
+        ValueError: If validation fails
+    """
+    # Check required fields
+    for field in schema.get("required", []):
+        if field not in config:
+            raise ValueError(f"Missing required field: {field}")
+    
+    # Check types of fields
+    properties = schema.get("properties", {})
+    for field, value in config.items():
+        if field in properties:
+            field_schema = properties[field]
+            field_type = field_schema.get("type")
+            
+            # Basic type checking
+            if field_type == "string" and not isinstance(value, str):
+                raise ValueError(f"Field {field} should be a string")
+            elif field_type == "array" and not isinstance(value, list):
+                raise ValueError(f"Field {field} should be an array")
+            elif field_type == "object" and not isinstance(value, dict):
+                raise ValueError(f"Field {field} should be an object")
+    
+    # For nested objects, recursively validate
+    for field, value in config.items():
+        if field in properties and properties[field].get("type") == "object" and isinstance(value, dict):
+            if "properties" in properties[field]:
+                basic_validate_config(value, properties[field])
+
+def load_server_configs() -> List[Dict[str, Any]]:
+    """
+    Load server configurations from JSON files in the config/servers directory.
+    
+    Returns:
+        List of validated server configurations
+    
+    Raises:
+        ValueError: If there are validation errors or duplicate server names
+    """
+    # Get the directory containing server configuration files
+    base_dir = Path(__file__).parent
+    servers_dir = base_dir / "servers"
+    
+    if not servers_dir.exists():
+        logger.warning(f"Servers directory not found: {servers_dir}. Creating it.")
+        servers_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Find all JSON files in the servers directory
+    config_files = list(servers_dir.glob("*.json"))
+    
+    if not config_files:
+        logger.warning("No server configuration files found.")
+        return []
+    
+    # Load and validate each configuration file
+    server_configs = []
+    server_names = set()
+    
+    for config_file in config_files:
+        try:
+            with open(config_file, "r") as f:
+                config = json.load(f)
+            
+            # Validate against schema
+            if HAVE_JSONSCHEMA:
+                jsonschema.validate(instance=config, schema=SERVER_CONFIG_SCHEMA)
+            else:
+                basic_validate_config(config, SERVER_CONFIG_SCHEMA)
+            
+            # Check for duplicate server names
+            server_name = config["server_name"]
+            if server_name in server_names:
+                raise ValueError(f"Duplicate server name found: {server_name} in {config_file}")
+            
+            server_names.add(server_name)
+            server_configs.append(config)
+            logger.info(f"Loaded configuration for server: {server_name} from {config_file.name}")
+        
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing JSON in {config_file}: {e}")
+            raise ValueError(f"Invalid JSON in {config_file}: {e}")
+        
+        except Exception as e:
+            logger.error(f"Error loading configuration from {config_file}: {e}")
+            raise
+    
+    logger.info(f"Loaded {len(server_configs)} server configurations")
+    return server_configs
+
+def create_server_map(server_configs: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """
+    Create a map of server names to endpoint configurations for MultiServerMCPClient.
+    
+    Args:
+        server_configs: List of server configurations
+    
+    Returns:
+        Dictionary mapping server names to endpoint configurations
+    """
+    return {
+        config["server_name"]: config["endpoint"]
+        for config in server_configs
+    }
+
+def get_allowed_tools_map(server_configs: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """
+    Create a map of server names to their allowed tools.
+    
+    Args:
+        server_configs: List of server configurations
+    
+    Returns:
+        Dictionary mapping server names to lists of allowed tools
+    """
+    return {
+        config["server_name"]: config["allowed_tools"]
+        for config in server_configs
+    }
+
+def get_sensitive_tools_map(server_configs: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """
+    Create a map of server names to their sensitive tools.
+    
+    Args:
+        server_configs: List of server configurations
+    
+    Returns:
+        Dictionary mapping server names to lists of sensitive tools
+    """
+    return {
+        config["server_name"]: config["sensitive_tools"]
+        for config in server_configs
+    }
+
+def namespace_tool_name(server_name: str, tool_name: str) -> str:
+    """
+    Create a namespaced tool name using underscore separator.
+    
+    Args:
+        server_name: Name of the server
+        tool_name: Original tool name
+    
+    Returns:
+        Namespaced tool name with underscore separator
+    """
+    # Use underscore instead of dot to comply with OpenAI's tool name pattern
+    return f"{server_name}_{tool_name}"
+
+def split_namespaced_tool(tool_name: str) -> tuple[str, str]:
+    """
+    Split a namespaced tool name into server and tool parts.
+    
+    Args:
+        tool_name: Namespaced tool name (e.g., "filesystem_read_file")
+    
+    Returns:
+        Tuple of (server_name, tool_name)
+    
+    Raises:
+        ValueError: If the tool name is not properly namespaced
+    """
+    # Split on the first underscore
+    parts = tool_name.split("_", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Invalid namespaced tool name: {tool_name}")
+    
+    return parts[0], parts[1]

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,0 +1,35 @@
+"""
+JSON schema for MCP server configurations
+"""
+
+SERVER_CONFIG_SCHEMA = {
+    "type": "object",
+    "required": ["server_name", "endpoint", "allowed_tools", "sensitive_tools"],
+    "properties": {
+        "server_name": {
+            "type": "string",
+            "description": "Unique name for the server"
+        },
+        "endpoint": {
+            "type": "object",
+            "required": ["command", "transport"],
+            "properties": {
+                "command": {"type": "string"},
+                "args": {"type": "array", "items": {"type": "string"}},
+                "env": {"type": "object"},
+                "transport": {"type": "string", "enum": ["stdio"]}
+            }
+        },
+        "allowed_tools": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of tools allowed from this server"
+        },
+        "sensitive_tools": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of tools requiring human approval"
+        }
+    },
+    "additionalProperties": False
+}

--- a/config/servers/context7.json
+++ b/config/servers/context7.json
@@ -1,0 +1,16 @@
+{
+  "server_name": "context7",
+  "endpoint": {
+    "command": "npx",
+    "args": [
+      "-y", 
+      "@upstash/context7-mcp@latest"
+    ],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "resolve-library-id",
+    "get-library-docs"
+  ],
+  "sensitive_tools": []
+}

--- a/config/servers/filesystem.json
+++ b/config/servers/filesystem.json
@@ -1,0 +1,30 @@
+{
+  "server_name": "filesystem",
+  "endpoint": {
+    "command": "npx",
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-filesystem",
+      "."
+    ],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "read_file",
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "list_directory",
+    "directory_tree",
+    "move_file",
+    "search_files",
+    "get_file_info",
+    "list_allowed_directories"
+  ],
+  "sensitive_tools": [
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "move_file"
+  ]
+}

--- a/config/servers/shell.json
+++ b/config/servers/shell.json
@@ -1,0 +1,19 @@
+{
+  "server_name": "shell",
+  "endpoint": {
+    "command": "uvx",
+    "args": [
+      "mcp-shell-server"
+    ],
+    "env": {
+      "ALLOW_COMMANDS": "ls,cat,pwd,grep,wc,touch,find,date,whoami"
+    },
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "shell_execute"
+  ],
+  "sensitive_tools": [
+    "shell_execute"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.1.0",
     "typing-extensions>=4.7.0",
     "python-dotenv>=0.21.0",
+    "jsonschema>=4.0.0",
     "flake8",
     "black"
 ]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,177 @@
+"""
+Tests for the configuration loader module
+"""
+
+import os
+import json
+import tempfile
+import pytest
+from pathlib import Path
+
+from config.loader import (
+    load_server_configs,
+    create_server_map,
+    get_allowed_tools_map,
+    get_sensitive_tools_map,
+    split_namespaced_tool,
+)
+
+
+@pytest.fixture
+def temp_config_dir():
+    """Create a temporary directory for test configuration files."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create servers directory
+        servers_dir = Path(temp_dir) / "servers"
+        servers_dir.mkdir()
+        
+        # Create a sample server configuration
+        fs_config = {
+            "server_name": "test_filesystem",
+            "endpoint": {
+                "command": "test_cmd",
+                "args": ["arg1", "arg2"],
+                "transport": "stdio"
+            },
+            "allowed_tools": ["read_file", "write_file"],
+            "sensitive_tools": ["write_file"]
+        }
+        
+        # Write to a JSON file
+        with open(servers_dir / "filesystem.json", "w") as f:
+            json.dump(fs_config, f)
+        
+        # Create another server config
+        context_config = {
+            "server_name": "test_context",
+            "endpoint": {
+                "command": "context_cmd",
+                "transport": "stdio"
+            },
+            "allowed_tools": ["get_docs"],
+            "sensitive_tools": []
+        }
+        
+        # Write to a JSON file
+        with open(servers_dir / "context.json", "w") as f:
+            json.dump(context_config, f)
+        
+        yield temp_dir
+
+
+def test_load_server_configs(temp_config_dir, monkeypatch):
+    """Test loading server configurations from JSON files."""
+    # Mock the base directory to use our temporary test directory
+    monkeypatch.setattr("config.loader.Path.__new__", lambda cls, *args, **kwargs: Path(temp_config_dir))
+    
+    # Load configurations
+    configs = load_server_configs()
+    
+    # Check if we loaded two configurations
+    assert len(configs) == 2
+    
+    # Check first configuration
+    fs_config = next(c for c in configs if c["server_name"] == "test_filesystem")
+    assert fs_config["endpoint"]["command"] == "test_cmd"
+    assert "read_file" in fs_config["allowed_tools"]
+    assert "write_file" in fs_config["sensitive_tools"]
+    
+    # Check second configuration
+    context_config = next(c for c in configs if c["server_name"] == "test_context")
+    assert context_config["endpoint"]["command"] == "context_cmd"
+    assert "get_docs" in context_config["allowed_tools"]
+    assert len(context_config["sensitive_tools"]) == 0
+
+
+def test_create_server_map():
+    """Test creating a server map from configurations."""
+    configs = [
+        {
+            "server_name": "server1",
+            "endpoint": {"command": "cmd1", "transport": "stdio"},
+            "allowed_tools": [],
+            "sensitive_tools": []
+        },
+        {
+            "server_name": "server2",
+            "endpoint": {"command": "cmd2", "transport": "stdio"},
+            "allowed_tools": [],
+            "sensitive_tools": []
+        }
+    ]
+    
+    server_map = create_server_map(configs)
+    
+    assert len(server_map) == 2
+    assert "server1" in server_map
+    assert "server2" in server_map
+    assert server_map["server1"]["command"] == "cmd1"
+    assert server_map["server2"]["command"] == "cmd2"
+
+
+def test_get_allowed_tools_map():
+    """Test getting allowed tools map from configurations."""
+    configs = [
+        {
+            "server_name": "server1",
+            "endpoint": {},
+            "allowed_tools": ["tool1", "tool2"],
+            "sensitive_tools": []
+        },
+        {
+            "server_name": "server2",
+            "endpoint": {},
+            "allowed_tools": ["tool3"],
+            "sensitive_tools": []
+        }
+    ]
+    
+    allowed_map = get_allowed_tools_map(configs)
+    
+    assert len(allowed_map) == 2
+    assert "server1" in allowed_map
+    assert "server2" in allowed_map
+    assert set(allowed_map["server1"]) == {"tool1", "tool2"}
+    assert set(allowed_map["server2"]) == {"tool3"}
+
+
+def test_get_sensitive_tools_map():
+    """Test getting sensitive tools map from configurations."""
+    configs = [
+        {
+            "server_name": "server1",
+            "endpoint": {},
+            "allowed_tools": [],
+            "sensitive_tools": ["tool1"]
+        },
+        {
+            "server_name": "server2",
+            "endpoint": {},
+            "allowed_tools": [],
+            "sensitive_tools": ["tool2", "tool3"]
+        }
+    ]
+    
+    sensitive_map = get_sensitive_tools_map(configs)
+    
+    assert len(sensitive_map) == 2
+    assert "server1" in sensitive_map
+    assert "server2" in sensitive_map
+    assert set(sensitive_map["server1"]) == {"tool1"}
+    assert set(sensitive_map["server2"]) == {"tool2", "tool3"}
+
+
+def test_split_namespaced_tool():
+    """Test splitting a namespaced tool name."""
+    server, tool = split_namespaced_tool("server1.tool1")
+    assert server == "server1"
+    assert tool == "tool1"
+    
+    # Test with multiple periods in the tool name
+    server, tool = split_namespaced_tool("server1.tool.with.dots")
+    assert server == "server1"
+    assert tool == "tool.with.dots"
+    
+    # Test error case
+    with pytest.raises(ValueError):
+        split_namespaced_tool("invalid_name_without_namespace")

--- a/tests/test_greeter.py
+++ b/tests/test_greeter.py
@@ -1,6 +1,8 @@
 import pytest
 from contextlib import asynccontextmanager
+from unittest.mock import patch, MagicMock
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
+from langchain_core.tools import BaseTool
 
 import mcp_graph_greeter as mg
 import greeter_service as gs
@@ -37,5 +39,67 @@ class DummyModel:
 
 def test_build_greeter_graph_compiles(monkeypatch):
     monkeypatch.setattr(mg, "ChatOpenAI", lambda model, api_key=None: DummyModel())
-    graph = mg.build_greeter_graph([])
+    graph = mg.build_greeter_graph([], {})
     assert graph is not None
+
+
+def test_review_tool_calls_with_namespaced_tools():
+    """Test the review_tool_calls function with namespaced tools."""
+    # Create a mock of necessary components
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(mg, "ChatOpenAI", lambda model, api_key=None: DummyModel())
+    
+    # Create a test tool
+    tool = BaseTool(name="test_server.test_tool", func=lambda x: "result")
+    
+    # Create a graph with the test tool and a sensitive tools map
+    sensitive_tools_map = {"test_server": ["test_tool"]}
+    graph = mg.build_greeter_graph([tool], sensitive_tools_map)
+    
+    # Test that the graph was created
+    assert graph is not None
+    
+    # Clean up
+    monkeypatch.undo()
+
+
+@pytest.mark.asyncio
+async def test_graph_factory_namespaces_tools(monkeypatch):
+    """Test that the graph factory properly namespaces tools."""
+    # Create mock server configs
+    mock_configs = [
+        {
+            "server_name": "test_server",
+            "endpoint": {"command": "test", "transport": "stdio"},
+            "allowed_tools": ["test_tool"],
+            "sensitive_tools": ["test_tool"]
+        }
+    ]
+    
+    # Create mock tools
+    mock_tool = MagicMock()
+    mock_tool.name = "test_tool"
+    mock_tool.metadata = {"server_name": "test_server"}
+    
+    # Create mocks
+    monkeypatch.setattr("config.loader.load_server_configs", lambda: mock_configs)
+    monkeypatch.setattr("config.loader.create_server_map", lambda x: {"test_server": {"command": "test", "transport": "stdio"}})
+    monkeypatch.setattr("langchain_mcp_adapters.client.MultiServerMCPClient", MagicMock)
+    monkeypatch.setattr(mg, "build_greeter_graph", lambda tools, sensitive_map: DummyGraph())
+    
+    # Mock the get_tools method to return our test tool
+    mock_client = MagicMock()
+    mock_client.get_tools.return_value = [mock_tool]
+    
+    # Mock the MultiServerMCPClient constructor
+    monkeypatch.setattr("langchain_mcp_adapters.client.MultiServerMCPClient.__new__", lambda cls, server_map: mock_client)
+    
+    # Test the graph factory
+    async with mg.graph_factory() as graph:
+        # Check that the graph was created
+        assert graph is not None
+        
+        # Check that the tool was properly namespaced
+        mock_client.get_tools.assert_called_once()
+        assert mock_tool.name == "test_server.test_tool"
+        assert mock_tool.metadata["original_name"] == "test_tool"


### PR DESCRIPTION
## Summary
- Implements server configurations in JSON files instead of hard-coded values
- Adds tool namespacing as `server_toolname` to avoid collisions
- Adds fallback validation when `jsonschema` package is not available
- Fixes OpenAI compatibility issues with tool names

## Test plan
- Run the LangGraph CLI with `uvx` to verify the system loads with no errors
- Test calling tools from multiple servers to verify namespacing works
- Try adding a new server configuration file to verify dynamic loading
- Verify that all tests pass with `pytest`

🤖 Generated with [Claude Code](https://claude.ai/code)