### PR TITLE
Implement namespaced server config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm install -g @modelcontextprotocol/server-filesystem
    - Copy `.env.example` to `.env`
    - Add your OpenAI API key to the `.env` file
    - Optionally change the model name from the default "gpt-4.1" to another OpenAI model
+   - To add additional MCP servers, place a JSON file in `config/servers/` describing its endpoint and tools
 
 ## Usage
 
@@ -108,7 +109,8 @@ if __name__ == "__main__":
 
 - `mcp_graph_greeter.py` - Main implementation of the graph and LangGraph CLI entry point
 - `greeter_service.py` - Service functions for using the greeter in applications
-- `config.py` - Configuration for the MCP server
+- `config/` - Package containing configuration utilities
+  - `servers/*.json` - Per-server endpoint and tool configuration
 - `demo.py` - Command-line demo script
 - `langgraph.json` - Configuration for the LangGraph CLI
 - `__init__.py` - Package definition

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -59,3 +59,16 @@ FILESYSTEM_SERVER = {"filesystem": MCP_SERVERS["filesystem"]}
 
 logger.info(f"Configured workspace directory: {WORKSPACE_DIR}")
 logger.info(f"Using LLM model: {LLM_MODEL_NAME}")
+
+from .loader import load_server_configs, ServerConfig, ConfigLoaderError
+
+__all__ = [
+    "MCP_SERVERS",
+    "FILESYSTEM_SERVER",
+    "OPENAI_API_KEY",
+    "LLM_MODEL_NAME",
+    "WORKSPACE_DIR",
+    "load_server_configs",
+    "ServerConfig",
+    "ConfigLoaderError",
+]

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict
+
+from . import WORKSPACE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServerConfig:
+    server_name: str
+    endpoint: Dict
+    allowed_tools: List[str]
+    sensitive_tools: List[str]
+
+
+class ConfigLoaderError(Exception):
+    pass
+
+
+def load_server_configs(directory: Path | str = Path(__file__).parent / "servers") -> List[ServerConfig]:
+    """Load server configurations from JSON files in ``directory``.
+
+    Parameters
+    ----------
+    directory : Path or str
+        Directory containing ``*.json`` server configuration files.
+
+    Returns
+    -------
+    List[ServerConfig]
+        Parsed server configurations.
+    """
+    dir_path = Path(directory)
+    configs: List[ServerConfig] = []
+    if not dir_path.exists():
+        raise ConfigLoaderError(f"Config directory not found: {dir_path}")
+
+    for json_file in dir_path.glob("*.json"):
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as e:  # JSONDecodeError or others
+            raise ConfigLoaderError(f"Failed to parse {json_file}: {e}")
+
+        missing = [k for k in ["server_name", "endpoint", "allowed_tools", "sensitive_tools"] if k not in data]
+        if missing:
+            raise ConfigLoaderError(f"{json_file}: missing keys: {', '.join(missing)}")
+        if not isinstance(data["allowed_tools"], list) or not isinstance(data["sensitive_tools"], list):
+            raise ConfigLoaderError(f"{json_file}: 'allowed_tools' and 'sensitive_tools' must be lists")
+
+        endpoint = data["endpoint"]
+        # Replace workspace placeholder if present in args
+        args = endpoint.get("args", [])
+        endpoint["args"] = [str(a).replace("${WORKSPACE_DIR}", str(WORKSPACE_DIR)) for a in args]
+
+        configs.append(
+            ServerConfig(
+                server_name=data["server_name"],
+                endpoint=endpoint,
+                allowed_tools=data["allowed_tools"],
+                sensitive_tools=data["sensitive_tools"],
+            )
+        )
+
+    return configs

--- a/config/servers/context7.json
+++ b/config/servers/context7.json
@@ -1,0 +1,13 @@
+{
+  "server_name": "context7",
+  "endpoint": {
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp@latest"],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "resolve-library-id",
+    "get-library-docs"
+  ],
+  "sensitive_tools": []
+}

--- a/config/servers/filesystem.json
+++ b/config/servers/filesystem.json
@@ -1,0 +1,26 @@
+{
+  "server_name": "filesystem",
+  "endpoint": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "${WORKSPACE_DIR}"],
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "read_file",
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "list_directory",
+    "directory_tree",
+    "move_file",
+    "search_files",
+    "get_file_info",
+    "list_allowed_directories"
+  ],
+  "sensitive_tools": [
+    "write_file",
+    "edit_file",
+    "create_directory",
+    "move_file"
+  ]
+}

--- a/config/servers/shell.json
+++ b/config/servers/shell.json
@@ -1,0 +1,15 @@
+{
+  "server_name": "shell",
+  "endpoint": {
+    "command": "uvx",
+    "args": ["mcp-shell-server"],
+    "env": {"ALLOW_COMMANDS": "ls,cat,pwd,grep,wc,touch,find,date,whoami"},
+    "transport": "stdio"
+  },
+  "allowed_tools": [
+    "shell_execute"
+  ],
+  "sensitive_tools": [
+    "shell_execute"
+  ]
+}

--- a/tests/test_greeter.py
+++ b/tests/test_greeter.py
@@ -39,3 +39,97 @@ def test_build_greeter_graph_compiles(monkeypatch):
     monkeypatch.setattr(mg, "ChatOpenAI", lambda model, api_key=None: DummyModel())
     graph = mg.build_greeter_graph([])
     assert graph is not None
+
+
+def test_load_server_configs():
+    configs = mg.load_server_configs()
+    assert any(c.server_name == "filesystem" for c in configs)
+
+
+@pytest.mark.asyncio
+async def test_graph_factory_namespaces(monkeypatch):
+    fs = mg.ServerConfig(
+        server_name="fs",
+        endpoint={},
+        allowed_tools=["write", "read"],
+        sensitive_tools=["write"],
+    )
+    sh = mg.ServerConfig(
+        server_name="sh",
+        endpoint={},
+        allowed_tools=["shell"],
+        sensitive_tools=["shell"],
+    )
+
+    monkeypatch.setattr(mg, "load_server_configs", lambda: [fs, sh])
+
+    class DummyTool:
+        def __init__(self, name, server):
+            self.name = name
+            self.metadata = {"server": server}
+
+    class DummyClient:
+        def __init__(self, servers):
+            pass
+
+        async def get_tools(self):
+            return [DummyTool("write", "fs"), DummyTool("shell", "sh")]
+
+    monkeypatch.setattr(mg, "MultiServerMCPClient", DummyClient)
+    monkeypatch.setattr(mg, "ChatOpenAI", lambda model, api_key=None: DummyModel())
+
+    captured = {}
+
+    def fake_build(tools, sensitive_tools=None):
+        captured["names"] = [t.name for t in tools]
+        captured["sens"] = sensitive_tools
+        return DummyGraph()
+
+    monkeypatch.setattr(mg, "build_greeter_graph", fake_build)
+
+    async with mg.graph_factory() as _:
+        pass
+
+    assert captured["names"] == ["fs.write", "sh.shell"]
+    assert captured["sens"] == ["fs.write", "sh.shell"]
+
+
+@pytest.mark.asyncio
+async def test_graph_factory_metadata_fallback(monkeypatch):
+    fs = mg.ServerConfig(
+        server_name="fs",
+        endpoint={},
+        allowed_tools=["write"],
+        sensitive_tools=[],
+    )
+
+    monkeypatch.setattr(mg, "load_server_configs", lambda: [fs])
+
+    class DummyTool:
+        def __init__(self, name):
+            self.name = name
+            self.metadata = {}
+
+    class DummyClient:
+        def __init__(self, servers):
+            pass
+
+        async def get_tools(self):
+            return [DummyTool("write")]
+
+    monkeypatch.setattr(mg, "MultiServerMCPClient", DummyClient)
+    monkeypatch.setattr(mg, "ChatOpenAI", lambda model, api_key=None: DummyModel())
+
+    captured = {}
+
+    def fake_build(tools, sensitive_tools=None):
+        captured["names"] = [t.name for t in tools]
+        return DummyGraph()
+
+    monkeypatch.setattr(mg, "build_greeter_graph", fake_build)
+
+    async with mg.graph_factory() as _:
+        pass
+
+    assert captured["names"] == ["fs.write"]
+


### PR DESCRIPTION
## Summary
- move `config.py` into package and export loader
- load per-server JSON configuration dynamically
- namespace tools per server in `graph_factory`
- add helper `split_namespaced`
- add loader tests and namespacing tests
- ensure missing tool metadata falls back to config
- document how to add servers

## Testing
- `python -m py_compile mcp_graph_greeter.py config/__init__.py config/loader.py tests/test_greeter.py greeter_service.py`
- `flake8` *(command not found)*
- `pytest -q` *(command not found)*